### PR TITLE
More robust array check

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -18,7 +18,7 @@
             var self = this;
             if (argument.isExpression || argument.isUnion) {
                 return self.render(argument);
-            } else if (argument instanceof Array) {
+            } else if (Array.isArray(argument)) {
                 return argument.map(function(e) {
                     return self.convertArgument(e);
                 });


### PR DESCRIPTION
instanceof doesn't work correctly if the `argument` is from a different window as `Array`.
Use `isArray` for a more robust check.